### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ English | [简体中文](README_zh.md)
 
 A TypeScript-based MCP (Model Context Protocol) server for generating images using Together AI API.
 
+<a href="https://glama.ai/mcp/servers/p1ctvg1l87">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/p1ctvg1l87/badge" alt="Together AI Image Server MCP server" />
+</a>
+
 ## Overview
 
 This server provides a simple interface to generate images using Together AI's image generation models through the MCP protocol. It allows Claude and other MCP-compatible assistants to generate images based on text prompts.


### PR DESCRIPTION
This PR adds a badge for the [Together AI Image Server](https://glama.ai/mcp/servers/p1ctvg1l87) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/p1ctvg1l87">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/p1ctvg1l87/badge" alt="Together AI Image Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.